### PR TITLE
Sanitization for build_settings_field & sanitize_setting

### DIFF
--- a/RationalOptionPages.php
+++ b/RationalOptionPages.php
@@ -576,6 +576,9 @@ class RationalOptionPages {
 									$input[ $field['id'] ] = false;
 								}
 								break;
+							default:
+								$input[ $field['id'] ] = strip_tags($input[ $field['id'] ]);
+								$input[ $field['id'] ] = esc_attr($input[ $field['id'] ]);								
 						}
 					}
 				}

--- a/RationalOptionPages.php
+++ b/RationalOptionPages.php
@@ -381,6 +381,10 @@ class RationalOptionPages {
 				}
 			}
 		}
+		
+		// Sanitize field values
+		$field['value'] = strip_tags($field['value']);		// Removes HTML tags
+		$field['value'] = esc_attr($field['value']);		// Escapes field for HTML attributes
 				
 		switch ( $field['type'] ) {
 			case 'checkbox':


### PR DESCRIPTION
Saving HTML into settings fields causes the refreshed page to break, and may be a security risk. Proposed enhancements for this wonderful class:

- In **build_settings_field:** Run $field['value'] through strip_tags and esc_attr, before form output.
- In **sanitize_setting:** Run $input through strip_tags and esc_attr, before it is sent to database.