### PR TITLE
Fix for multiple Select saving

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,22 @@ $pages = array(
 							'option-two'	=> __( 'Option Two', 'sample-domain' ),
 						),
 					),
+					'select-multiple'		=> array(
+						'title'			=> __( 'Select multiple', 'sample-domain' ),
+						'type'			=> 'select',
+						'value' => array(
+							'option-two'
+						),
+						'choices' => array(
+							'option-one' => __( 'Option One', 'sample-domain' ),
+							'option-two' => __( 'Option Two', 'sample-domain' ),
+							'option-three' => __( 'Option Three', 'sample-domain' ),
+						),
+						'attributes' => array(
+							'multiple' => 'multiple'
+						),
+						'sanitize' => true
+					),
 					'textarea'		=> array(
 						'title'			=> __( 'Textarea', 'sample-domain' ),
 						'type'			=> 'textarea',

--- a/RationalOptionPages.php
+++ b/RationalOptionPages.php
@@ -581,6 +581,11 @@ class RationalOptionPages {
 							continue;
 						}
 						switch ( $field['type'] ) {
+							case 'select':
+								if ( !empty($input[$field['id']]) && !empty($input['attributes']['multiple']) ) {
+									$input[ $field['id'] ] = $input[ $field['id'] ];
+								}
+								break;
 							case 'checkbox':
 								if ( empty( $input[ $field['id'] ] ) ) {
 									$input[ $field['id'] ] = false;


### PR DESCRIPTION
Hi Jeremy,
i did some tests but it still doesn't work, i.e. it keeps saving the field as an empty string.

After a little look at the class, I think I've solved the problem.
In the `sanitize_setting()` function, I made sure to sanitize the `select` with `multiple` attribute giving it the base value as an array and not as in the `case` of `default` where it is sanitized in string.

After this change, both `multiple` and non `select` works.

I proceeded to send you a pull request. I wait your feedback.

As you see I updated the README.md with the example for multiple selection, you can use that to test the changes.

Best regards,
Stefano.