### PR TITLE
Fixed field label composition

### DIFF
--- a/RationalOptionPages.php
+++ b/RationalOptionPages.php
@@ -271,7 +271,7 @@ class RationalOptionPages {
 								!in_array( $field_params['type'], array( 'radio' ) ) &&
 								( empty( $field_params['no_label'] ) || $field_params['no_label'] === false )
 							) {
-								$params['title'] = '<label for="{$params["id"]}">'.__($params['title'],'text-domain').'</label>';
+								$params['title'] = "<label for='{$params["id"]}'>".__($params['title'],'text-domain')."</label>";
 							}
 		
 							// Finalize callback


### PR DESCRIPTION
While applying some custom styling to the labels, I noticed [this problem](https://imgur.com/a/plKsdmq) with the variable interpolation.

So I inverted quotes and double quotes so the interpolation would work correctly.